### PR TITLE
Feature/plant modal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Base URL of the upstream plants API (no trailing slash).
+# Copy this file to .env and set the value for your environment.
+PLANTS_API_URL=http://your-plants-api-host:8000/plants

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,8 @@ jobs:
         run: npm install
 
       - name: Build project
+        env:
+          PLANTS_API_URL: ${{ secrets.PLANTS_API_URL }}
         run: |
           export NODE_ENV=production
           npm run build

--- a/README.md
+++ b/README.md
@@ -16,13 +16,27 @@ npm run preview      # preview production build
 
 ---
 
+## Configuration
+
+Copy `.env.example` to `.env` and set the values before running the app:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Description |
+|---|---|
+| `PLANTS_API_URL` | Base URL of the upstream plants API (no trailing slash). Consumed by `src/routes/api/plants/+server.ts`. |
+
+---
+
 ## API Reference
 
 ### `GET /api/plants`
 
 Proxy endpoint for the upstream plants API. Returns a list of plant records filtered by the provided geographic identifiers.
 
-**Base URL (upstream):** `http://100.109.30.31:8000/plants`
+**Base URL (upstream):** configured via the `PLANTS_API_URL` environment variable (see [Configuration](#configuration))
 
 #### Query Parameters
 
@@ -60,7 +74,7 @@ Returns a JSON array of [Plant](#plant) objects, or an error object on failure.
 
 ### Upstream Filter Parameters
 
-These query parameters are supported by the upstream API at `http://100.109.30.31:8000/plants` but are not yet forwarded by the SvelteKit proxy. They can be added to `+server.ts` as needed.
+These query parameters are supported by the upstream API (the URL configured via `PLANTS_API_URL`) but are not yet forwarded by the SvelteKit proxy. They can be added to `src/routes/api/plants/+server.ts` as needed.
 
 #### Identification
 

--- a/README.md
+++ b/README.md
@@ -1,38 +1,246 @@
-# sv
+# WFF Prototype
 
-Everything you need to build a Svelte project, powered by [`sv`](https://github.com/sveltejs/cli).
+A SvelteKit map application for exploring native plant species by geographic region, ecoregion, and plant hardiness zone.
 
-## Creating a project
+---
 
-If you're seeing this, you've probably already done this step. Congrats!
-
-```bash
-# create a new project in the current directory
-npx sv create
-
-# create a new project in gardenmap
-npx sv create gardenmap
-```
-
-## Developing
-
-Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
+## Development
 
 ```bash
-npm run dev
-
-# or start the server and open the app in a new browser tab
-npm run dev -- --open
+npm install
+npm run dev          # start dev server
+npm run dev -- --open  # start and open in browser
+npm run build        # production build
+npm run preview      # preview production build
 ```
 
-## Building
+---
 
-To create a production version of your app:
+## API Reference
 
-```bash
-npm run build
+### `GET /api/plants`
+
+Proxy endpoint for the upstream plants API. Returns a list of plant records filtered by the provided geographic identifiers.
+
+**Base URL (upstream):** `http://100.109.30.31:8000/plants`
+
+#### Query Parameters
+
+The SvelteKit proxy currently forwards the following parameters to the upstream API:
+
+| Parameter   | Type    | Default | Constraints       | Description |
+|-------------|---------|---------|-------------------|-------------|
+| `ecoregion` | string  | —       | —                 | EPA Level III ecoregion code (e.g. `"9.4.1"`). Filters plants native to this ecoregion. |
+| `zone`      | string  | —       | —                 | USDA Plant Hardiness Zone label (e.g. `"7b"`). Filters plants hardy in this zone. |
+| `zipcode`   | string  | —       | pattern `^\d{5}$` | US ZIP code. Used as an alternative or supplement to `ecoregion`/`zone`. |
+| `offset`    | integer | `0`     | min `0`           | Pagination offset. |
+| `limit`     | integer | `250`   | `1`–`250`         | Fixed at `250` by the proxy; not exposed as a client parameter. |
+
+The upstream API supports additional filter parameters that are not yet forwarded by the proxy. See [Upstream Filter Parameters](#upstream-filter-parameters) below.
+
+#### Example Request
+
+```
+GET /api/plants?ecoregion=9.4.1&zone=7b
 ```
 
-You can preview the production build with `npm run preview`.
+#### Response
 
-> To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+Returns a JSON array of [Plant](#plant) objects, or an error object on failure.
+
+**Success — `200 OK`:** JSON array of [Plant](#plant) objects.
+
+**Error — `500 Internal Server Error`**
+
+```json
+{ "error": "Description of what went wrong" }
+```
+
+---
+
+### Upstream Filter Parameters
+
+These query parameters are supported by the upstream API at `http://100.109.30.31:8000/plants` but are not yet forwarded by the SvelteKit proxy. They can be added to `+server.ts` as needed.
+
+#### Identification
+
+| Parameter         | Type   | Constraints    | Description |
+|-------------------|--------|----------------|-------------|
+| `scientific_name` | string | max 100 chars  | Partial match on scientific name. |
+| `common_name`     | string | max 100 chars  | Partial match on any common name (array search). |
+| `plant_family`    | string | max 100 chars  | Filter by plant family. |
+| `plant_type`      | string | max 100 chars  | Filter by plant type (array search, e.g. `Tree`, `Shrub`, `Forb/Herb`). |
+
+#### Physical Characteristics
+
+| Parameter            | Type    | Constraints     | Description |
+|----------------------|---------|-----------------|-------------|
+| `height_min_ft`      | number  | `0`–`500`       | Minimum mature height in feet. |
+| `height_max_ft`      | number  | `0`–`500`       | Maximum mature height in feet. |
+| `showy`              | boolean | —               | Has showy flowers. |
+| `flower_colors`      | string  | max 25 chars    | Filter by flower color (array search). |
+| `fall_color`         | string  | max 25 chars    | Filter by fall foliage color. |
+| `evergreen_deciduous`| string  | `Evergreen`, `Deciduous` | Leaf retention behavior. |
+| `growth_rate`        | string  | `Slow`, `Moderate`, `Rapid` | Growth rate category. |
+| `lifespan`           | string  | `Annual`, `Biennial`, `Perennial` | Plant lifespan (array search). |
+| `duration`           | string  | `Long`, `Moderate`, `Short` | Duration category. |
+| `flowering_months`   | string  | Month name (e.g. `June`) | Filter by a flowering month (array search). |
+
+#### Growing Conditions
+
+| Parameter           | Type   | Constraints              | Description |
+|---------------------|--------|--------------------------|-------------|
+| `sun_and_shade`     | string | `Shade`, `Part-Shade`, `Sun` | Light requirement (array search). |
+| `soil_moisture`     | string | `Dry`, `Moist`, `Wet`    | Soil moisture requirement (array search). |
+| `drought_tolerance` | string | `None`, `Low`, `Medium`, `High` | Drought tolerance level. |
+| `salt_tolerance`    | string | `None`, `Low`, `Medium`, `High` | Salt tolerance level. |
+| `fire_tolerance`    | string | `None`, `Low`, `Medium`, `High` | Fire tolerance level. |
+| `ph_min`            | number | `0`–`14`                 | Minimum soil pH. |
+| `ph_max`            | number | `0`–`14`                 | Maximum soil pH. |
+
+#### Wildlife Value
+
+| Parameter                  | Type    | Description |
+|----------------------------|---------|-------------|
+| `monarchs`                 | boolean | Attracts monarch butterflies. |
+| `native_bees`              | boolean | Attracts native bees. |
+| `honey_bees`               | boolean | Attracts honey bees. |
+| `bombus`                   | boolean | Attracts bumblebees. |
+| `butterflies`              | boolean | Attracts butterflies. |
+| `moths`                    | boolean | Attracts moths. |
+| `hummingbirds`             | boolean | Attracts hummingbirds. |
+| `beetles_wasps_flies`      | boolean | Attracts beetles, wasps, or flies. |
+| `bats`                     | boolean | Attracts bats. |
+| `nesting_and_structure_bees` | boolean | Provides nesting structure for bees. |
+| `larval_host_monarch`      | boolean | Serves as larval host for monarchs. |
+| `larval_host_butterfly`    | boolean | Serves as larval host for butterflies. |
+| `larval_host_moth`         | boolean | Serves as larval host for moths. |
+
+---
+
+## Data Dictionary
+
+### Plant
+
+Represents a single plant record returned by `/api/plants`.
+
+#### Identification
+
+| Field             | Type       | Description |
+|-------------------|------------|-------------|
+| `id`              | `string`   | Unique identifier for the plant record. |
+| `name`            | `string`   | Display name. |
+| `scientific_name` | `string`   | Botanical (Latin) name. |
+| `common_name`     | `string[]` | One or more common names. |
+| `plant_family`    | `string`   | Plant family (e.g. `"Asteraceae"`). |
+| `plant_type`      | `string[]` | Plant categories (e.g. `"Tree"`, `"Shrub"`, `"Forb/Herb"`). |
+| `image_url`       | `string`   | URL of a representative plant image. |
+
+#### Physical Characteristics
+
+| Field                 | Type       | Description |
+|-----------------------|------------|-------------|
+| `height_min_ft`       | `number`   | Minimum mature height in feet. |
+| `height_max_ft`       | `number`   | Maximum mature height in feet. |
+| `showy`               | `boolean`  | Has showy flowers. |
+| `flower_colors`       | `string[]` | Flower colors. |
+| `fall_color`          | `string`   | Fall foliage color. |
+| `evergreen_deciduous` | `string`   | `"Evergreen"` or `"Deciduous"`. |
+| `growth_rate`         | `string`   | `"Slow"`, `"Moderate"`, or `"Rapid"`. |
+| `lifespan`            | `string[]` | `"Annual"`, `"Biennial"`, and/or `"Perennial"`. |
+| `duration`            | `string`   | `"Long"`, `"Moderate"`, or `"Short"`. |
+| `flowering_months`    | `string[]` | Months in which the plant flowers (e.g. `["May", "June"]`). |
+
+#### Growing Conditions
+
+| Field                | Type       | Description |
+|----------------------|------------|-------------|
+| `sun_and_shade`      | `string[]` | Light requirements: `"Shade"`, `"Part-Shade"`, `"Sun"`. |
+| `soil_moisture`      | `string[]` | Soil moisture needs: `"Dry"`, `"Moist"`, `"Wet"`. |
+| `drought_tolerance`  | `string`   | `"None"`, `"Low"`, `"Medium"`, or `"High"`. |
+| `salt_tolerance`     | `string`   | `"None"`, `"Low"`, `"Medium"`, or `"High"`. |
+| `fire_tolerance`     | `string`   | `"None"`, `"Low"`, `"Medium"`, or `"High"`. |
+| `ph_min`             | `number`   | Minimum soil pH (0–14). |
+| `ph_max`             | `number`   | Maximum soil pH (0–14). |
+
+#### Wildlife Value
+
+| Field                        | Type      | Description |
+|------------------------------|-----------|-------------|
+| `monarchs`                   | `boolean` | Attracts monarch butterflies. |
+| `native_bees`                | `boolean` | Attracts native bees. |
+| `honey_bees`                 | `boolean` | Attracts honey bees. |
+| `bombus`                     | `boolean` | Attracts bumblebees. |
+| `butterflies`                | `boolean` | Attracts butterflies. |
+| `moths`                      | `boolean` | Attracts moths. |
+| `hummingbirds`               | `boolean` | Attracts hummingbirds. |
+| `beetles_wasps_flies`        | `boolean` | Attracts beetles, wasps, or flies. |
+| `bats`                       | `boolean` | Attracts bats. |
+| `nesting_and_structure_bees` | `boolean` | Provides nesting structure for bees. |
+| `larval_host_monarch`        | `boolean` | Serves as larval host for monarchs. |
+| `larval_host_butterfly`      | `boolean` | Serves as larval host for butterflies. |
+| `larval_host_moth`           | `boolean` | Serves as larval host for moths. |
+
+---
+
+### USDA Plant Hardiness Zones (PHZ)
+
+Source shapefile: `static/shapefiles/plant-hardiness-zones/`  
+Processed GeoJSON: `static/geodata/phz.geojson` / `static/geodata/phz.json`
+
+| Field       | Description |
+|-------------|-------------|
+| `Id`        | Internal record identifier. |
+| `gridcode`  | Numeric grid code corresponding to the zone. |
+| `zone`      | Zone label (e.g. `"7b"`). Used as the `zone` query parameter. |
+| `trange`    | Average annual extreme minimum temperature range for this zone (°F). |
+| `zonetitle` | Full human-readable zone title. |
+
+**Source:** [USDA Agricultural Research Service — Plant Hardiness Zone Map (2023)](https://planthardiness.ars.usda.gov/)
+
+---
+
+### EPA Level III Ecoregions
+
+Source shapefile: `static/shapefiles/ecoregions/`  
+Processed GeoJSON: `static/geodata/ecoregions.geojson` / `static/geodata/ecoregions.json`
+
+| Field        | Description |
+|--------------|-------------|
+| `US_L3CODE`  | US Level III ecoregion code. Used as the `ecoregion` query parameter. |
+| `US_L3NAME`  | US Level III ecoregion name. |
+| `NA_L3CODE`  | North American Level III ecoregion code. |
+| `NA_L3NAME`  | North American Level III ecoregion name. |
+| `NA_L2CODE`  | North American Level II ecoregion code (parent of Level III). |
+| `NA_L2NAME`  | North American Level II ecoregion name. |
+| `NA_L1CODE`  | North American Level I ecoregion code (broadest classification). |
+| `NA_L1NAME`  | North American Level I ecoregion name. |
+| `L3_KEY`     | Composite key: `NA_L3CODE` + `US_L3NAME`. |
+| `L2_KEY`     | Composite key: `NA_L2CODE` + `NA_L2NAME`. |
+| `L1_KEY`     | Composite key: `NA_L1CODE` + `NA_L1NAME`. |
+| `Shape_Leng` | Perimeter length of the polygon (map units). |
+| `Shape_Area` | Area of the polygon (map units). |
+
+**Source:** [US EPA Level III and IV Ecoregions](https://www.epa.gov/eco-research/level-iii-and-iv-ecoregions-continental-united-states)
+
+---
+
+## Static Data Files
+
+| File | Description |
+|------|-------------|
+| `static/layers-list.json` | List of available map overlay layers with display names, file paths, and descriptions. |
+| `static/properties.json` | Lists attribute field names for each shapefile dataset (`phz`, `ecoregions`). |
+| `static/geodata/phz.json` | Processed PHZ topology/feature data (browser-optimized). |
+| `static/geodata/ecoregions.json` | Processed ecoregion topology/feature data (browser-optimized). |
+| `static/geodata-big/` | Full-resolution GeoJSON files (not served to browser; used for processing). |
+
+---
+
+## TODO / Open Questions
+
+- [ ] Verify all response field names and types against actual API responses (schema above is inferred from query param names).
+- [ ] Clarify how `zipcode` is resolved upstream — is it used to derive `ecoregion`/`zone`, or filtered directly?
+- [ ] Expose additional upstream filter parameters in the proxy as UI filtering needs grow.
+- [ ] Add upstream API authentication requirements if/when credentials are needed.
+- [ ] Confirm complete set of `plant_type` enum values.

--- a/src/lib/components/CandidatePlants.svelte
+++ b/src/lib/components/CandidatePlants.svelte
@@ -27,14 +27,14 @@
 		[...new Set(plants.flatMap((p) => p.sun_and_shade ?? []))].sort()
 	);
 	const moistureOptions = $derived(
-		[...new Set(plants.map((p) => p.moisture_use).filter(Boolean) as string[])].sort()
+		[...new Set(plants.flatMap((p) => p.soil_moisture ?? []))].sort()
 	);
 
 	const filteredPlants = $derived(
 		plants.filter((p) => {
 			if (filterPlantType && !(p.plant_type ?? []).includes(filterPlantType)) return false;
 			if (filterSunShade && !(p.sun_and_shade ?? []).includes(filterSunShade)) return false;
-			if (filterMoisture && p.moisture_use !== filterMoisture) return false;
+			if (filterMoisture && !(p.soil_moisture ?? []).includes(filterMoisture)) return false;
 			return true;
 		})
 	);

--- a/src/lib/components/CandidatePlants.svelte
+++ b/src/lib/components/CandidatePlants.svelte
@@ -1,15 +1,7 @@
 <script lang="ts">
 	import PlantIcon1 from '$lib/icons/noun-plant-6741.svg';
-
-	interface Plant {
-		id: string;
-		name: string;
-		scientific_name?: string;
-		common_name: Array<string>;
-		plant_type?: Array<string>;
-		sun_and_shade?: Array<string>;
-		moisture_use?: string;
-	}
+	import PlantModal from '$lib/components/PlantModal.svelte';
+	import type { Plant } from '$lib/components/PlantModal.svelte';
 
 	interface CandidatePlantsProps {
 		ecoregion?: string;
@@ -22,6 +14,7 @@
 	let plants: Plant[] = $state([]);
 	let loading = $state(false);
 	let error: string | null = $state(null);
+	let selectedPlant: Plant | null = $state(null);
 
 	let filterPlantType = $state('');
 	let filterSunShade = $state('');
@@ -137,16 +130,24 @@
 
 		<div class="grid w-full grid-cols-5 gap-2 p-4">
 			{#each filteredPlants as plant (plant.id)}
-				<div class="flex aspect-square flex-col items-center justify-center gap-1">
-					<img src={PlantIcon1} alt={plant.scientific_name} class="h-xl w-xl" />
+				<button
+					type="button"
+					class="flex aspect-square cursor-pointer flex-col items-center justify-center gap-1 rounded p-1 hover:bg-stone-100"
+					onclick={() => (selectedPlant = plant)}
+				>
+					<img src={plant.image_url ?? PlantIcon1} alt={plant.scientific_name} class="h-xl w-xl" />
 					<span class="text-center text-[12px] leading-tight">{plant.scientific_name}</span>
 					<span class="text-center text-[10px] leading-tight italic">
 						{plant.common_name.join(', ')}
 					</span>
-				</div>
+				</button>
 			{/each}
 		</div>
 	{:else if ecoregion || phzZone || zipcode}
 		<p class="mt-2 text-[11px] italic text-stone-600">No candidate plants found.</p>
 	{/if}
 </div>
+
+{#if selectedPlant}
+	<PlantModal plant={selectedPlant} onclose={() => (selectedPlant = null)} />
+{/if}

--- a/src/lib/components/CandidatePlants.svelte
+++ b/src/lib/components/CandidatePlants.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import PlantIcon1 from '$lib/icons/noun-plant-6741.svg';
 	import PlantModal from '$lib/components/PlantModal.svelte';
-	import type { Plant } from '$lib/components/PlantModal.svelte';
+	import type { Plant } from '$lib/types/plant.js';
 
 	interface CandidatePlantsProps {
 		ecoregion?: string;

--- a/src/lib/components/PlantModal.svelte
+++ b/src/lib/components/PlantModal.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import PlantIcon1 from '$lib/icons/noun-plant-6741.svg';
+
+	export interface Plant {
+		id: string;
+		name: string;
+		scientific_name?: string;
+		common_name: Array<string>;
+		plant_type?: Array<string>;
+		sun_and_shade?: Array<string>;
+		moisture_use?: string;
+		image_url?: string;
+	}
+
+	interface PlantModalProps {
+		plant: Plant;
+		onclose: () => void;
+	}
+
+	let { plant, onclose }: PlantModalProps = $props();
+</script>
+
+<div
+	role="presentation"
+	class="fixed inset-0 z-[9999] flex items-center justify-center bg-black/40"
+	onclick={(e) => { if (e.target === e.currentTarget) onclose(); }}
+>
+	<div
+		role="dialog"
+		aria-modal="true"
+		aria-label={plant.scientific_name}
+		tabindex="-1"
+		class="relative w-96 max-w-[90vw] rounded-xl bg-white p-6 shadow-2xl"
+	>
+		<button
+			type="button"
+			class="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-800"
+			onclick={onclose}
+			aria-label="Close"
+		>
+			&times;
+		</button>
+
+		<img
+			src={plant.image_url ?? PlantIcon1}
+			alt={plant.scientific_name}
+			class="mx-auto mb-4 h-40 w-40 object-contain"
+		/>
+
+		<p class="text-center text-base font-semibold leading-snug text-stone-800">
+			{plant.scientific_name}
+		</p>
+		<p class="mt-1 text-center text-sm italic text-stone-500">
+			{plant.common_name.join(', ')}
+		</p>
+
+		<!-- More detail sections go here -->
+	</div>
+</div>

--- a/src/lib/components/PlantModal.svelte
+++ b/src/lib/components/PlantModal.svelte
@@ -6,9 +6,15 @@
 		name: string;
 		scientific_name?: string;
 		common_name: Array<string>;
+		plant_family?: string;
 		plant_type?: Array<string>;
+		height_min_ft?: number;
+		height_max_ft?: number;
+		growth_rate?: string;
+		lifespan?: Array<string>;
+		flowering_months?: Array<string>;
 		sun_and_shade?: Array<string>;
-		moisture_use?: string;
+		soil_moisture?: Array<string>;
 		image_url?: string;
 	}
 
@@ -18,6 +24,13 @@
 	}
 
 	let { plant, onclose }: PlantModalProps = $props();
+
+	function heightRange(min?: number, max?: number): string {
+		if (min != null && max != null) return `${min}–${max} ft`;
+		if (min != null) return `${min}+ ft`;
+		if (max != null) return `up to ${max} ft`;
+		return '';
+	}
 </script>
 
 <div
@@ -30,7 +43,7 @@
 		aria-modal="true"
 		aria-label={plant.scientific_name}
 		tabindex="-1"
-		class="relative w-96 max-w-[90vw] rounded-xl bg-white p-6 shadow-2xl"
+		class="relative w-[28rem] max-w-[92vw] rounded-xl bg-white p-6 shadow-2xl"
 	>
 		<button
 			type="button"
@@ -41,19 +54,77 @@
 			&times;
 		</button>
 
-		<img
-			src={plant.image_url ?? PlantIcon1}
-			alt={plant.scientific_name}
-			class="mx-auto mb-4 h-40 w-40 object-contain"
-		/>
+		<!-- Header: icon left, names right -->
+		<div class="flex items-center gap-4 pr-6">
+			<img
+				src={plant.image_url ?? PlantIcon1}
+				alt={plant.scientific_name}
+				class="h-20 w-20 shrink-0 rounded-lg object-contain"
+			/>
+			<div class="min-w-0">
+				<p class="text-base font-semibold leading-snug text-stone-800">
+					{plant.scientific_name ?? plant.name}
+				</p>
+				{#if plant.common_name.length}
+					<p class="mt-0.5 text-sm italic text-stone-500">
+						{plant.common_name.join(', ')}
+					</p>
+				{/if}
+			</div>
+		</div>
 
-		<p class="text-center text-base font-semibold leading-snug text-stone-800">
-			{plant.scientific_name}
-		</p>
-		<p class="mt-1 text-center text-sm italic text-stone-500">
-			{plant.common_name.join(', ')}
-		</p>
-
-		<!-- More detail sections go here -->
+		<!-- Info table -->
+		<table class="mt-4 w-full border-collapse text-sm">
+			<tbody>
+				{#if plant.plant_family}
+					<tr class="border-t border-stone-100">
+						<th class="w-2/5 py-1.5 pr-3 text-left font-medium text-stone-500">Family</th>
+						<td class="py-1.5 text-stone-800">{plant.plant_family}</td>
+					</tr>
+				{/if}
+				{#if plant.plant_type?.length}
+					<tr class="border-t border-stone-100">
+						<th class="w-2/5 py-1.5 pr-3 text-left font-medium text-stone-500">Type</th>
+						<td class="py-1.5 text-stone-800">{plant.plant_type.join(', ')}</td>
+					</tr>
+				{/if}
+				{#if heightRange(plant.height_min_ft, plant.height_max_ft)}
+					<tr class="border-t border-stone-100">
+						<th class="w-2/5 py-1.5 pr-3 text-left font-medium text-stone-500">Height</th>
+						<td class="py-1.5 text-stone-800">{heightRange(plant.height_min_ft, plant.height_max_ft)}</td>
+					</tr>
+				{/if}
+				{#if plant.growth_rate}
+					<tr class="border-t border-stone-100">
+						<th class="w-2/5 py-1.5 pr-3 text-left font-medium text-stone-500">Growth rate</th>
+						<td class="py-1.5 text-stone-800">{plant.growth_rate}</td>
+					</tr>
+				{/if}
+				{#if plant.lifespan?.length}
+					<tr class="border-t border-stone-100">
+						<th class="w-2/5 py-1.5 pr-3 text-left font-medium text-stone-500">Lifespan</th>
+						<td class="py-1.5 text-stone-800">{plant.lifespan.join(', ')}</td>
+					</tr>
+				{/if}
+				{#if plant.flowering_months?.length}
+					<tr class="border-t border-stone-100">
+						<th class="w-2/5 py-1.5 pr-3 text-left font-medium text-stone-500">Flowering</th>
+						<td class="py-1.5 text-stone-800">{plant.flowering_months.join(', ')}</td>
+					</tr>
+				{/if}
+				{#if plant.sun_and_shade?.length}
+					<tr class="border-t border-stone-100">
+						<th class="w-2/5 py-1.5 pr-3 text-left font-medium text-stone-500">Sun / shade</th>
+						<td class="py-1.5 text-stone-800">{plant.sun_and_shade.join(', ')}</td>
+					</tr>
+				{/if}
+				{#if plant.soil_moisture?.length}
+					<tr class="border-t border-stone-100">
+						<th class="w-2/5 py-1.5 pr-3 text-left font-medium text-stone-500">Soil moisture</th>
+						<td class="py-1.5 text-stone-800">{plant.soil_moisture.join(', ')}</td>
+					</tr>
+				{/if}
+			</tbody>
+		</table>
 	</div>
 </div>

--- a/src/lib/components/PlantModal.svelte
+++ b/src/lib/components/PlantModal.svelte
@@ -1,22 +1,7 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import PlantIcon1 from '$lib/icons/noun-plant-6741.svg';
-
-	export interface Plant {
-		id: string;
-		name: string;
-		scientific_name?: string;
-		common_name: Array<string>;
-		plant_family?: string;
-		plant_type?: Array<string>;
-		height_min_ft?: number;
-		height_max_ft?: number;
-		growth_rate?: string;
-		lifespan?: Array<string>;
-		flowering_months?: Array<string>;
-		sun_and_shade?: Array<string>;
-		soil_moisture?: Array<string>;
-		image_url?: string;
-	}
+	import type { Plant } from '$lib/types/plant.js';
 
 	interface PlantModalProps {
 		plant: Plant;
@@ -24,6 +9,39 @@
 	}
 
 	let { plant, onclose }: PlantModalProps = $props();
+
+	let closeBtn: HTMLButtonElement;
+	let dialogEl: HTMLDivElement;
+
+	onMount(() => closeBtn?.focus());
+
+	function trapFocus(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			e.preventDefault();
+			onclose();
+			return;
+		}
+		if (e.key !== 'Tab') return;
+		const focusable = Array.from(
+			dialogEl.querySelectorAll<HTMLElement>(
+				'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])'
+			)
+		).filter((el) => !el.closest('[inert]'));
+		if (!focusable.length) return;
+		const first = focusable[0];
+		const last = focusable[focusable.length - 1];
+		if (e.shiftKey) {
+			if (document.activeElement === first) {
+				e.preventDefault();
+				last.focus();
+			}
+		} else {
+			if (document.activeElement === last) {
+				e.preventDefault();
+				first.focus();
+			}
+		}
+	}
 
 	function heightRange(min?: number, max?: number): string {
 		if (min != null && max != null) return `${min}–${max} ft`;
@@ -43,6 +61,8 @@
 		aria-modal="true"
 		aria-label={plant.scientific_name}
 		tabindex="-1"
+		onkeydown={trapFocus}
+		bind:this={dialogEl}
 		class="relative w-[28rem] max-w-[92vw] rounded-xl bg-white p-6 shadow-2xl"
 	>
 		<button
@@ -50,6 +70,7 @@
 			class="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-800"
 			onclick={onclose}
 			aria-label="Close"
+			bind:this={closeBtn}
 		>
 			&times;
 		</button>

--- a/src/lib/types/plant.ts
+++ b/src/lib/types/plant.ts
@@ -1,0 +1,16 @@
+export interface Plant {
+	id: string;
+	name: string;
+	scientific_name?: string;
+	common_name: Array<string>;
+	plant_family?: string;
+	plant_type?: Array<string>;
+	height_min_ft?: number;
+	height_max_ft?: number;
+	growth_rate?: string;
+	lifespan?: Array<string>;
+	flowering_months?: Array<string>;
+	sun_and_shade?: Array<string>;
+	soil_moisture?: Array<string>;
+	image_url?: string;
+}

--- a/src/routes/api/plants/+server.ts
+++ b/src/routes/api/plants/+server.ts
@@ -1,3 +1,4 @@
+import { PLANTS_API_URL } from '$env/static/private';
 import type { RequestHandler } from '@sveltejs/kit';
 
 export const GET: RequestHandler = async ({ url }) => {
@@ -13,14 +14,14 @@ export const GET: RequestHandler = async ({ url }) => {
 		if (zipcode) params.set('zipcode', zipcode);
         params.set('limit', '250');
 
-		const response = await fetch(`http://100.109.30.31:8000/plants?${params.toString()}`);
+		const response = await fetch(`${PLANTS_API_URL}?${params.toString()}`);
 
 		if (!response.ok) {
 			throw new Error(`API request failed: ${response.status}`);
 		}
 
 		const data = await response.json();
-		console.log('plants data:', `http://100.109.30.31:8000/plants?${params.toString()}`);
+		console.log('plants data:', `${PLANTS_API_URL}?${params.toString()}`);
 		return new Response(JSON.stringify(data), {
 			headers: { 'Content-Type': 'application/json' }
 		});


### PR DESCRIPTION
This pull request introduces a detailed API and data dictionary to the `README.md`, and adds a modal dialog for viewing plant details in the UI. It also refactors the plant type definition and improves how plant filtering and display work in the candidate plants component.

**Documentation improvements:**

- Expanded `README.md` with a comprehensive API reference for `/api/plants`, a full data dictionary for plant objects and supporting geodata, and a list of open questions and TODOs. This provides clear guidance for both backend and frontend development.

**UI/UX enhancements:**

- Added a new `PlantModal.svelte` component that displays detailed information about a selected plant in a modal dialog, including scientific name, common names, family, type, height, growth rate, lifespan, flowering months, sun/shade, and soil moisture.
- Updated `CandidatePlants.svelte` to allow users to click on a plant to open the modal with its details, and to use the plant's image if available, falling back to a default icon.

**Type and filtering improvements:**

- Refactored the `Plant` type definition to be shared between components, ensuring consistency and supporting the new modal. [[1]](diffhunk://#diff-43223e8c7243b358857095678b7f430e421c00eb34129553d681090a47281deeL3-R4) [[2]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2R1-R130)
- Improved filtering logic in `CandidatePlants.svelte` so that soil moisture is now treated as an array (`soil_moisture`), matching the data dictionary and supporting more accurate filtering and option generation. [[1]](diffhunk://#diff-43223e8c7243b358857095678b7f430e421c00eb34129553d681090a47281deeL37-R37) [[2]](diffhunk://#diff-43223e8c7243b358857095678b7f430e421c00eb34129553d681090a47281deeR17)