### PR TITLE
Adjust mobile header, add OG tags, and implement a11y fixes

### DIFF
--- a/src/lib/components/LocationInfo.svelte
+++ b/src/lib/components/LocationInfo.svelte
@@ -36,7 +36,7 @@
 			onclick={() => infoModalLayer = layer}
 			aria-label={`About this data: ${layer.name}`}
 		>
-			<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
 			</svg>
 		</button>

--- a/src/lib/components/LocationInfo.svelte
+++ b/src/lib/components/LocationInfo.svelte
@@ -50,10 +50,10 @@
 		<!-- USDA Hardiness Zone column -->
 		<div class="flex-1 min-w-0 p-4 flex flex-col gap-1 border-t sm:border-t-0 sm:border-l border-stone-400">
 			{#if pointLayerData.phz}
-				<h4 class="font-semibold text-base tracking-wide leading-tight flex items-center gap-1">
+				<h2 class="font-semibold text-base tracking-wide leading-tight flex items-center gap-1">
 					USDA 2023 Plant Hardiness Zone
 					{@render infoButton(phzLayer)}
-				</h4>
+				</h2>
 				{#if pointLayerData.phz.zone}
 					<div class="font-mono text-3xl font-bold leading-none text-stone-800 mt-1">{pointLayerData.phz.zone}</div>
 				{/if}
@@ -70,10 +70,10 @@
 		<!-- Ecoregion column -->
 		<div class="flex-1 min-w-0 p-4 flex flex-col gap-1 border-t sm:border-t-0 sm:border-l border-stone-400">
 			{#if pointLayerData.ecoregions}
-				<h4 class="font-semibold text-base tracking-wide leading-tight flex items-center gap-1">
+				<h2 class="font-semibold text-base tracking-wide leading-tight flex items-center gap-1">
 					North American Ecoregions - Level III
 					{@render infoButton(ecoregionsLayer)}
-				</h4>
+				</h2>
 				{#if pointLayerData.ecoregions.NA_L3NAME}
 					<div class="mt-1 flex flex-col gap-2">
 						<div class="hidden sm:block">

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -398,7 +398,13 @@ export function removeSearchMarker(): void {
 }
 </script>
 
-<div bind:this={mapContainer} class="map-container" style="width:100%;height:100%;overflow:hidden;"></div>
+<div
+  bind:this={mapContainer}
+  class="map-container"
+  role="application"
+  aria-label="Interactive map. Use arrow keys to pan and the plus and minus keys to zoom."
+  style="width:100%;height:100%;overflow:hidden;"
+></div>
 
 <style>
   .map-container {

--- a/src/lib/components/Map.svelte
+++ b/src/lib/components/Map.svelte
@@ -401,8 +401,8 @@ export function removeSearchMarker(): void {
 <div
   bind:this={mapContainer}
   class="map-container"
-  role="application"
-  aria-label="Interactive map. Use arrow keys to pan and the plus and minus keys to zoom."
+  role="region"
+  aria-label="Interactive map of the selected location. Use arrow keys to pan and the plus and minus keys to zoom."
   style="width:100%;height:100%;overflow:hidden;"
 ></div>
 

--- a/src/lib/components/PlantModal.svelte
+++ b/src/lib/components/PlantModal.svelte
@@ -152,7 +152,7 @@
 {#snippet heartButton()}
 	<button
 		type="button"
-		class="absolute right-20 top-3 flex h-7 w-7 items-center justify-center rounded-full hover:bg-stone-100 {saved
+		class="absolute right-20 top-3 flex h-7 w-7 items-center justify-center rounded-full bg-white/90 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 {saved
 			? 'text-red-600'
 			: 'text-stone-500 hover:text-stone-800'}"
 		onclick={() => savedPlants.toggle(saveTarget)}
@@ -174,7 +174,7 @@
 	<div class="absolute right-12 top-3">
 		<button
 			type="button"
-			class="flex h-7 w-7 items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-800"
+			class="flex h-7 w-7 items-center justify-center rounded-full bg-white/90 text-stone-500 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 hover:text-stone-800"
 			onclick={copyLink}
 			aria-label="Copy link to this plant"
 		>
@@ -226,33 +226,34 @@
 						alt={plant.scientific_name}
 						class="absolute inset-0 h-full w-full object-cover"
 					/>
+					{#if images.length > 1}
+						<!-- Prev/next arrows, vertically centered on each side of the photo -->
+						<button
+							type="button"
+							class="absolute left-2 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/40 text-white backdrop-blur-sm hover:bg-black/60"
+							onclick={prevImage}
+							aria-label="Previous image"
+						>
+							<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+							</svg>
+						</button>
+						<button
+							type="button"
+							class="absolute right-2 top-1/2 flex h-10 w-10 -translate-y-1/2 items-center justify-center rounded-full bg-black/40 text-white backdrop-blur-sm hover:bg-black/60"
+							onclick={nextImage}
+							aria-label="Next image"
+						>
+							<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+							</svg>
+						</button>
+					{/if}
 				</div>
-				{#if currentAttribution || images.length > 1}
-					<!-- Thin gallery bar: Last | attribution | Next -->
-					<div class="flex shrink-0 items-center gap-2 px-2 py-1 text-[10px] text-white/70">
-						{#if images.length > 1}
-							<button
-								type="button"
-								class="shrink-0 px-1 hover:text-white"
-								onclick={prevImage}
-								aria-label="Previous image"
-							>‹ Last</button>
-						{:else}
-							<span class="w-10 shrink-0"></span>
-						{/if}
-						<span class="min-w-0 flex-1 truncate text-center text-white/60">
-							{currentAttribution ?? ''}
-						</span>
-						{#if images.length > 1}
-							<button
-								type="button"
-								class="shrink-0 px-1 hover:text-white"
-								onclick={nextImage}
-								aria-label="Next image"
-							>Next ›</button>
-						{:else}
-							<span class="w-10 shrink-0"></span>
-						{/if}
+				{#if currentAttribution}
+					<!-- Attribution bar: full width now that arrows overlay the photo -->
+					<div class="shrink-0 px-2 py-1 text-center text-[12px] text-white/60">
+						{currentAttribution}
 					</div>
 				{/if}
 			</div>
@@ -263,7 +264,7 @@
 				{@render shareButton()}
 				<button
 					type="button"
-					class="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-800"
+					class="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full bg-white/90 text-stone-500 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 hover:text-stone-800"
 					onclick={onclose}
 					aria-label="Close"
 					bind:this={closeBtn}
@@ -357,7 +358,7 @@
 			{@render shareButton()}
 			<button
 				type="button"
-				class="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full text-stone-500 hover:bg-stone-100 hover:text-stone-800"
+				class="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full bg-white/90 text-stone-500 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 hover:text-stone-800"
 				onclick={onclose}
 				aria-label="Close"
 				bind:this={closeBtn}

--- a/src/lib/components/PlantModal.svelte
+++ b/src/lib/components/PlantModal.svelte
@@ -159,7 +159,7 @@
 		aria-pressed={saved}
 		aria-label={saved ? 'Remove from My Saved Plants' : 'Add to My Saved Plants'}
 	>
-		<svg class="h-4 w-4" fill={saved ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24">
+		<svg class="h-4 w-4" fill={saved ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 			<path
 				stroke-linecap="round"
 				stroke-linejoin="round"
@@ -179,11 +179,11 @@
 			aria-label="Copy link to this plant"
 		>
 			{#if copied}
-				<svg class="h-4 w-4 text-lime-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<svg class="h-4 w-4 text-lime-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 				</svg>
 			{:else}
-				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 					<path
 						stroke-linecap="round"
 						stroke-linejoin="round"
@@ -234,7 +234,7 @@
 							onclick={prevImage}
 							aria-label="Previous image"
 						>
-							<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
 							</svg>
 						</button>
@@ -244,7 +244,7 @@
 							onclick={nextImage}
 							aria-label="Next image"
 						>
-							<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
 							</svg>
 						</button>

--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -91,7 +91,7 @@
 
 <div class={isSplash ? 'w-full flex flex-col gap-2' : 'w-full flex flex-col relative'}>
 	<!-- Mode toggle: search by location or by plant name -->
-	<div class={isSplash ? 'flex gap-1 self-start text-[13px]' : 'flex gap-1 self-start px-3 pt-2 text-[13px]'}>
+	<div class={isSplash ? 'flex gap-1 self-start text-[13px] [text-shadow:0_1px_3px_rgba(0,0,0,0.9)]' : 'flex gap-1 self-start px-3 pt-2 text-[13px]'}>
 		<button
 			type="button"
 			class={`rounded-t border-b-2 px-3 py-1 font-medium transition-colors ${

--- a/src/lib/components/SearchBar.svelte
+++ b/src/lib/components/SearchBar.svelte
@@ -141,7 +141,7 @@
 						aria-label="Clear plant search"
 						title="Clear search"
 					>
-						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
 						</svg>
 					</button>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -85,6 +85,12 @@
 </InfoModal>
 
 <div class="flex h-screen flex-col overflow-hidden bg-stone-300">
+	<a
+		href="#main-content"
+		class="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[2000] focus:rounded focus:bg-stone-100 focus:px-4 focus:py-2 focus:font-semibold focus:text-lime-950 focus:shadow-lg focus:ring-2 focus:ring-lime-800"
+	>
+		Skip to main content
+	</a>
 	<header
 		class="flex flex-col-reverse gap-2 bg-lime-950 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-0"
 	>
@@ -123,7 +129,7 @@
 		</nav>
 	</header>
 
-	<main class="flex min-h-0 flex-1 flex-col overflow-hidden">
+	<main id="main-content" tabindex="-1" class="flex min-h-0 flex-1 flex-col overflow-hidden">
 		{#if mounted}
 			{@render children()}
 		{:else}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -85,23 +85,32 @@
 </InfoModal>
 
 <div class="flex h-screen flex-col overflow-hidden bg-stone-300">
-	<header class="flex items-center justify-between bg-lime-950 p-4">
-		<a href="/" class="flex items-center gap-3">
+	<header
+		class="flex flex-col-reverse gap-2 bg-lime-950 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-0"
+	>
+		<a
+			href="/"
+			class="flex w-full items-center justify-between gap-3 sm:w-auto sm:justify-start"
+		>
 			<h1 class="font-serif text-xl font-bold text-stone-100 sm:text-3xl">My Native Plant List</h1>
-			<span
-				role="img"
-				aria-label="The Sustainable Gardening Institute"
-				class="inline-block h-8 bg-stone-100 sm:h-10"
-				style="aspect-ratio: 163.7 / 88; mask: url(/logos/sgi.svg) center / contain no-repeat; -webkit-mask: url(/logos/sgi.svg) center / contain no-repeat;"
-			></span>
-			<span
-				role="img"
-				aria-label="White Flower Farm"
-				class="inline-block h-8 bg-stone-100 sm:h-10"
-				style="aspect-ratio: 811.7 / 724.5; mask: url(/logos/wff.svg) center / contain no-repeat; -webkit-mask: url(/logos/wff.svg) center / contain no-repeat;"
-			></span>
+			<div class="flex items-center gap-3">
+				<span
+					role="img"
+					aria-label="The Sustainable Gardening Institute"
+					class="inline-block h-8 bg-stone-100 sm:h-10"
+					style="aspect-ratio: 163.7 / 88; mask: url(/logos/sgi.svg) center / contain no-repeat; -webkit-mask: url(/logos/sgi.svg) center / contain no-repeat;"
+				></span>
+				<span
+					role="img"
+					aria-label="White Flower Farm"
+					class="inline-block h-8 bg-stone-100 sm:h-10"
+					style="aspect-ratio: 811.7 / 724.5; mask: url(/logos/wff.svg) center / contain no-repeat; -webkit-mask: url(/logos/wff.svg) center / contain no-repeat;"
+				></span>
+			</div>
 		</a>
-		<nav class="flex items-center gap-4">
+		<nav
+			class="-mx-4 -mt-4 flex w-[calc(100%+2rem)] items-center justify-end gap-4 bg-stone-950 px-4 py-2 sm:m-0 sm:w-auto sm:bg-transparent sm:p-0"
+		>
 			<button
 				onclick={() => (showAbout = true)}
 				class="text-sm text-stone-300 transition-colors hover:text-stone-100">About</button

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -340,7 +340,41 @@
 
 <svelte:head>
 	<title>My Native Plant List</title>
-	<meta name="description" content="Explore geographic data with interactive maps" />
+	<meta
+		name="description"
+		content="Find plants native to your ecoregion, hardy in your USDA zone, and commercially available. A free tool from The Sustainable Gardening Institute and White Flower Farm."
+	/>
+	<link rel="canonical" href="https://mynativeplantlist.com/" />
+
+	<!-- Open Graph -->
+	<meta property="og:type" content="website" />
+	<meta property="og:site_name" content="My Native Plant List" />
+	<meta property="og:title" content="My Native Plant List" />
+	<meta
+		property="og:description"
+		content="Find plants native to your ecoregion, hardy in your USDA zone, and commercially available."
+	/>
+	<meta property="og:url" content="https://mynativeplantlist.com/" />
+	<meta property="og:image" content="https://mynativeplantlist.com/img/splash.jpg" />
+	<meta property="og:image:width" content="1600" />
+	<meta property="og:image:height" content="1066" />
+	<meta
+		property="og:image:alt"
+		content="A garden of native plants in bloom"
+	/>
+
+	<!-- Twitter Card -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta name="twitter:title" content="My Native Plant List" />
+	<meta
+		name="twitter:description"
+		content="Find plants native to your ecoregion, hardy in your USDA zone, and commercially available."
+	/>
+	<meta name="twitter:image" content="https://mynativeplantlist.com/img/splash.jpg" />
+	<meta
+		name="twitter:image:alt"
+		content="A garden of native plants in bloom"
+	/>
 </svelte:head>
 
 {#if showSplash}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -413,9 +413,9 @@
 				</div>
 			</div>
 		</div>
-		<p class="absolute bottom-4 left-0 right-0 z-10 text-center text-xs text-stone-300/80">
+		<footer class="absolute bottom-4 left-0 right-0 z-10 text-center text-xs text-stone-300/80">
 			© 2025-{new Date().getFullYear()} White Flower Farm and Sustainable Gardening Institute
-		</p>
+		</footer>
 	</div>
 {:else}
 	<div


### PR DESCRIPTION
**Accessibility Improvements:**
* Added a "Skip to main content" link and labeled the main content area with `id="main-content"` and `tabindex="-1"` for better keyboard navigation. Navigation and header structure were improved for screen readers. (`src/routes/+layout.svelte`) [[1]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL88-R102) [[2]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR115-R119) [[3]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL117-R132)
* Set `role="application"` and an ARIA label on the map container to clarify its interactive purpose for assistive technologies. (`src/lib/components/Map.svelte`)

**UI/Visual Enhancements:**
* Updated plant modal image gallery: navigation arrows now overlay the image with improved styling and SVG icons, and the attribution bar is separated and full-width. Modal action buttons (heart, share, close) now have a consistent, more visible style to not get lost on mobile. (`src/lib/components/PlantModal.svelte`) [[1]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L155-R155) [[2]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L177-R177) [[3]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L229-R257) [[4]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L266-R267) [[5]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L360-R361)
* Promoted section headings in location info from `<h4>` to `<h2>` for better document structure and accessibility. (`src/lib/components/LocationInfo.svelte`) [[1]](diffhunk://#diff-632f64c8dfb849767887e881008cd36985b43e95b3c4e4a096a779c3fc86efa6L53-R56) [[2]](diffhunk://#diff-632f64c8dfb849767887e881008cd36985b43e95b3c4e4a096a779c3fc86efa6L73-R76)
* Improved the search mode toggle's text shadow for better contrast on the splash page. (`src/lib/components/SearchBar.svelte`)

**Content and Metadata Updates:**
* Expanded `<head>` metadata on the splash page to include a detailed description, canonical URL, Open Graph, and Twitter Card tags for enhanced SEO and social sharing. (`src/routes/+page.svelte`)
* Changed the copyright
  notice to a `<footer>` element for semantic correctness. (`src/routes/+page.svelte`)