### PR TITLE
Enhance geocoding API and improve backup lookup functionality

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,9 +3,3 @@
 # the API share an origin, so the browser calls /api/* directly and this isn't needed.
 # Copy this file to .env and set the value for your environment.
 PLANTS_API_URL=https://your-plants-api-host/api/plants
-
-# Optional. Geocodio API key used as a backup reverse geocoder when Nominatim
-# returns no ZIP code for a clicked map point. If unset, the fallback is skipped.
-# NOTE: this is a client-side (static) app, so this key is inlined into the
-# browser bundle — restrict it by domain/referrer in the Geocodio dashboard.
-VITE_GEOCODIO_API_KEY=your-geocodio-api-key

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built with SvelteKit (Svelte 5 runes), Leaflet for the map, Turf.js for point-in
 
 The app has two complementary flows, both driven from the home page ([src/routes/+page.svelte](src/routes/+page.svelte)):
 
-- **Location → plants.** Clicking the map or searching a ZIP code geocodes the point (client-side, via Nominatim, with Geocodio as a ZIP-code fallback), resolves which hardiness zone / ecoregion polygon contains it (client-side, via Turf), and fetches the plants appropriate for that location.
+- **Location → plants.** Clicking the map or searching a ZIP code geocodes the point (client-side, via the mynativeplantlist ZIP API, with Nominatim as a fallback), resolves which hardiness zone / ecoregion polygon contains it (client-side, via Turf), and fetches the plants appropriate for that location.
 - **Plant name → suitability.** Searching by plant name lists catalog matches and, once a location is set, annotates each match with whether it suits that location.
 
 Geocoding and the polygon lookup happen in the browser against bundled GeoJSON. Plant data is fetched directly from the browser via [src/lib/api/plants.ts](src/lib/api/plants.ts), which calls the plants API at the same-origin path `/api/plants/*`. In production the site and the API share an origin (`mynativeplantlist.com/api/...`), so these calls need no CORS; in local development the Vite dev server proxies `/api/*` to the API origin given by `PLANTS_API_URL` (see [vite.config.ts](vite.config.ts)).
@@ -29,7 +29,7 @@ src/
                                   #   (paged), name search + suitability, detail, summary
     components/                   # Map, SearchBar, LocationInfo, CandidatePlants,
                                   #   PlantFilters, PlantModal, PlantSearchResults, InfoModal
-    services/geocoding.ts         # Nominatim geocoding (rate-limited, US-only) + Geocodio ZIP fallback
+    services/geocoding.ts         # mynativeplantlist ZIP geocoding, with Nominatim fallback (rate-limited, US-only)
     services/spatial-analysis.ts  # Turf point-in-polygon over bundled layers
     plant-filters.ts              # Canonical filter options + shared filter state
     types/plant.ts                # PlantSummary, PlantSearchResult, Plant, PlantImage
@@ -65,7 +65,6 @@ cp .env.example .env
 | Variable | Description |
 |---|---|
 | `PLANTS_API_URL` | Plants API endpoint, e.g. `https://your-plants-api-host/api/plants`. Used **only by the Vite dev server** to proxy `/api/*` during local development (only its origin is read — see [vite.config.ts](vite.config.ts)). In production the site and API share an origin, so the browser calls `/api/*` directly and this is not needed. |
-| `VITE_GEOCODIO_API_KEY` | **Optional.** [Geocodio](https://www.geocod.io/) API key used as a backup reverse geocoder when Nominatim returns no ZIP code for a clicked point. If unset, the fallback is skipped. Because this is a static client-side app, the key is inlined into the browser bundle — restrict it by domain/referrer in the Geocodio dashboard. |
 
 ---
 
@@ -168,9 +167,9 @@ Returned by `fetchPlantDetail`. Extends [PlantSummary](#plantsummary) with:
 
 ### Geocoding — [src/lib/services/geocoding.ts](src/lib/services/geocoding.ts)
 
-`GeocodingService` calls the OpenStreetMap **Nominatim** API directly from the browser for forward (`searchLocation`) and reverse (`reverseGeocode`) geocoding. Requests are throttled to one per second and limited to the US (`countrycodes=us`). A forward search requires a 5-digit (or ZIP+4) US ZIP code in the query.
+`GeocodingService.reverseGeocode` (used for map clicks and "use my location") calls mynativeplantlist's `/api/zip` endpoints as the primary source: `GET /api/zip?longitude=&latitude=` maps a point to a ZIP code (Census Bureau data, either a `"contains"` match or the `"nearest"` known ZIP), then `GET /api/zip/{zipcode}` resolves that ZIP to town/state metadata (a small number of ZIPs aren't in the metadata dataset — handled as ZIP-only, no town/state). If the primary lookup fails entirely, `reverseGeocode` falls back to the OpenStreetMap **Nominatim** reverse API.
 
-Nominatim doesn't always return a ZIP code for a clicked point. When `reverseGeocode` gets no result or a result missing a `postcode`, it falls back to **Geocodio** to recover the ZIP — backfilling it into Nominatim's address when one exists, or building the result from Geocodio otherwise. The fallback requires `VITE_GEOCODIO_API_KEY` and is skipped when the key is unset.
+`GeocodingService.searchLocation` (forward ZIP-text search) still calls Nominatim directly, since it needs to resolve a typed ZIP to map coordinates, which the mynativeplantlist endpoints don't provide. Nominatim requests are throttled to one per second and limited to the US (`countrycodes=us`); a forward search requires a 5-digit (or ZIP+4) US ZIP code in the query.
 
 ### Spatial analysis — [src/lib/services/spatial-analysis.ts](src/lib/services/spatial-analysis.ts)
 

--- a/src/lib/components/CandidatePlants.svelte
+++ b/src/lib/components/CandidatePlants.svelte
@@ -35,6 +35,10 @@
 	let loading = $state(false);
 	let error: string | null = $state(null);
 	let selectedPlant: PlantSummary | null = $state(null);
+	// The backend's per-zipcode data can be incomplete. When a zipcode lookup comes back
+	// empty, fall back to the ecoregion/hardiness-zone already resolved client-side
+	// (point-in-polygon against the bundled geodata) instead of showing nothing.
+	let usingFallback = $state(false);
 
 	// A shared link (?plant=<id>) reopens that plant's modal on load, independent of
 	// whatever location/filters are also in the URL.
@@ -84,12 +88,17 @@
 
 	const activeFilterCount = $derived(countActiveFilters(filters));
 
+	// Zipcode takes priority over ecoregion/zone, unless the zipcode lookup already came
+	// back empty for this location (see maybeFallBackToLocation below).
 	function locationParams(): URLSearchParams {
 		const params = new URLSearchParams();
+		if (zipcode && !usingFallback) {
+			params.set('zipcode', zipcode);
+			return params;
+		}
 		if (ecoregion) params.set('ecoregion', ecoregion);
 		// The API takes the hardiness zone as a bare integer (e.g. "7b" -> "7").
 		if (phzZone) params.set('hardiness_zone', phzZone.match(/^\d+/)?.[0] ?? phzZone);
-		if (zipcode) params.set('zipcode', zipcode);
 		return params;
 	}
 
@@ -98,6 +107,7 @@
 		fetchCandidatePlants(locationParams(), signal)
 			.then((data) => {
 				allSummaries = data;
+				maybeFallBackToLocation(data);
 			})
 			.catch((err: unknown) => {
 				// Ignore aborts and backend errors; the "of N" count just stays hidden.
@@ -105,12 +115,28 @@
 			});
 	}
 
-	// Plain (non-reactive) variable used to detect location changes without itself being a tracked dep
+	/**
+	 * If a zipcode-based lookup came back with zero plants total (not just zero after
+	 * filtering) and we have ecoregion/hardiness-zone data for this spot, switch to
+	 * querying by those instead. One-shot per location: `usingFallback` only flips false->true.
+	 */
+	function maybeFallBackToLocation(unfilteredData: PlantSummary[]) {
+		if (!usingFallback && zipcode && (ecoregion || phzZone) && unfilteredData.length === 0) {
+			usingFallback = true;
+		}
+	}
+
+	// Plain (non-reactive) variables used to detect location/fallback changes without
+	// themselves being tracked deps.
 	let prevLocationKey = '';
+	let prevUsingFallback = false;
 
 	$effect(() => {
-		// Read ALL reactive deps at the top so Svelte tracks them even when we return early
-		const locationKey = [ecoregion, phzZone, zipcode].join('|');
+		// Read ALL reactive deps at the top so Svelte tracks them even when we return early.
+		// Identity is zipcode alone when present: ecoregion/phzZone resolve asynchronously
+		// (point-in-polygon lookup) slightly after the zipcode is known, and that arrival
+		// shouldn't be treated as a brand-new location (which would clear filters/results).
+		const locationKey = zipcode || [ecoregion, phzZone].join('|');
 		const ft = filters.plantType;
 		const fs = filters.sunShade;
 		const fm = filters.moisture;
@@ -118,6 +144,7 @@
 
 		if (!ecoregion && !phzZone && !zipcode) {
 			prevLocationKey = locationKey;
+			prevUsingFallback = usingFallback = false;
 			allSummaries = [];
 			plants = [];
 			loading = false;
@@ -133,6 +160,7 @@
 		// new place). The very first load is exempt so splash pre-selections survive.
 		if (hadRealPreviousLocation) {
 			prevLocationKey = locationKey;
+			prevUsingFallback = usingFallback = false;
 			allSummaries = [];
 			plants = [];
 			loading = true;
@@ -157,9 +185,11 @@
 
 		const controller = new AbortController();
 
-		// First load arriving with pre-selected filters (from the splash): the main fetch is
-		// filtered, so seed the unfiltered total separately for the "of N" count.
-		if (isNewLocation && filtersActive) {
+		// Re-seed the unfiltered total whenever this is a new location OR the zip->ecoregion
+		// fallback just switched on (the previously seeded total was zip-based and is now stale).
+		const fallbackJustSwitched = usingFallback !== prevUsingFallback;
+		prevUsingFallback = usingFallback;
+		if ((isNewLocation || fallbackJustSwitched) && filtersActive) {
 			seedTotals(controller.signal);
 		}
 
@@ -167,7 +197,10 @@
 			.then((data) => {
 				plants = data;
 				// An unfiltered fetch also seeds the total for the "of N" count.
-				if (!filtersActive) allSummaries = data;
+				if (!filtersActive) {
+					allSummaries = data;
+					maybeFallBackToLocation(data);
+				}
 			})
 			.catch((err: unknown) => {
 				if (err instanceof Error && err.name === 'AbortError') return;

--- a/src/lib/components/CandidatePlants.svelte
+++ b/src/lib/components/CandidatePlants.svelte
@@ -154,7 +154,7 @@
 		const isNewLocation = locationKey !== prevLocationKey;
 		// A real previous location (not the initial mount or the empty/no-location key).
 		const hadRealPreviousLocation =
-			isNewLocation && prevLocationKey !== '' && prevLocationKey !== '||';
+			isNewLocation && prevLocationKey !== '' && prevLocationKey !== '|';
 
 		// Moving between two real locations: drop stale filters (selections may not fit the
 		// new place). The very first load is exempt so splash pre-selections survive.

--- a/src/lib/components/PlantModal.svelte
+++ b/src/lib/components/PlantModal.svelte
@@ -47,7 +47,9 @@
 		clearTimeout(copiedTimeout);
 		const currentUrl = untrack(() => $page.url);
 		// Only clean up the URL if this modal still "owns" the current plant param.
-		if (currentUrl.searchParams.get('plant') !== plant.id) return;
+		// searchParams values are always strings, so coerce plant.id (which the API
+		// can return as a number despite the PlantSummary type) before comparing.
+		if (currentUrl.searchParams.get('plant') !== String(plant.id)) return;
 		const params = new URLSearchParams(currentUrl.searchParams);
 		params.delete('plant');
 		const query = params.toString();

--- a/src/lib/services/geocoding.ts
+++ b/src/lib/services/geocoding.ts
@@ -5,7 +5,7 @@ export class GeocodingService {
   private static readonly RATE_LIMIT_MS = 1000; // 1 second between requests
   private static readonly USER_AGENT = 'GardenMap/1.0 (https://github.com/tylermachado/gardenmap)';
   private static requestQueue: Promise<void> = Promise.resolve();
-  private static readonly GEOCODIO_API_KEY = import.meta.env.VITE_GEOCODIO_API_KEY as string | undefined;
+  private static readonly ZIP_API_BASE = 'https://www.mynativeplantlist.com/api/zip';
 
   private static hasZipcode(query: string): boolean {
     // Match 5-digit or 5+4 digit ZIP codes
@@ -29,6 +29,70 @@ export class GeocodingService {
   }
 
   static async reverseGeocode(lat: number, lon: number): Promise<SearchResult | null> {
+    const primary = await this.zipLookup(lat, lon);
+    if (primary) return primary;
+
+    return this.nominatimReverse(lat, lon);
+  }
+
+  /**
+   * Primary reverse geocoder: mynativeplantlist's Census-backed ZIP lookup.
+   * Returns null (rather than throwing) on any failure so callers fall back
+   * to Nominatim.
+   */
+  private static async zipLookup(lat: number, lon: number): Promise<SearchResult | null> {
+    try {
+      const response = await fetch(
+        `${this.ZIP_API_BASE}?longitude=${lon}&latitude=${lat}`
+      );
+      if (!response.ok) return null;
+
+      const data = await response.json();
+      const zipcode: string | undefined = data?.zipcode;
+      if (!zipcode) return null;
+
+      const meta = await this.zipMetadata(zipcode);
+
+      return {
+        lat,
+        lon,
+        display_name: meta ? `${meta.city}, ${meta.state} ${zipcode}` : zipcode,
+        address: {
+          postcode: zipcode,
+          city: meta?.city,
+          state: meta?.state
+        }
+      };
+    } catch (error) {
+      console.error('ZIP lookup failed:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Looks up town/state metadata for a ZIP code. A small set of ZIP codes
+   * aren't present in this dataset (404) — treated as "no metadata" rather
+   * than an error, since the ZIP itself is still usable.
+   */
+  private static async zipMetadata(
+    zipcode: string
+  ): Promise<{ city?: string; state?: string } | null> {
+    try {
+      const response = await fetch(`${this.ZIP_API_BASE}/${zipcode}`);
+      if (!response.ok) return null;
+
+      const data = await response.json();
+      return { city: data?.city, state: data?.state };
+    } catch (error) {
+      console.error('ZIP metadata lookup failed:', error);
+      return null;
+    }
+  }
+
+  /**
+   * Backup reverse geocoder, used only when the primary ZIP lookup fails.
+   */
+  private static async nominatimReverse(lat: number, lon: number): Promise<SearchResult | null> {
     try {
       const response = await this.rateLimitedFetch(
         `https://nominatim.openstreetmap.org/reverse?format=json&lat=${lat}&lon=${lon}&addressdetails=1&countrycodes=us`
@@ -37,66 +101,11 @@ export class GeocodingService {
       const result = response.ok ? await response.json() : null;
 
       const hasUsAddress = result?.address && result.address.country_code === 'us';
-      const nominatim: SearchResult | null = hasUsAddress
+      return hasUsAddress
         ? { lat, lon, address: result.address, display_name: result.display_name }
         : null;
-
-      // Nominatim doesn't always return a postcode for a point. Fall back to
-      // Geocodio to recover the ZIP so downstream ZIP-based lookups still work.
-      if (nominatim?.address.postcode) return nominatim;
-
-      const geocodio = await this.geocodioReverse(lat, lon);
-      if (!geocodio) return nominatim;
-
-      if (nominatim) {
-        // Keep Nominatim's richer address, just backfill the missing ZIP.
-        nominatim.address.postcode = geocodio.address.postcode;
-        return nominatim;
-      }
-
-      return geocodio;
     } catch (error) {
       console.error('Reverse geocoding failed:', error);
-      return null;
-    }
-  }
-
-  /**
-   * Backup reverse geocoder. Returns a result only when Geocodio yields a US
-   * ZIP code. Requires VITE_GEOCODIO_API_KEY; a no-op when it's unset.
-   */
-  private static async geocodioReverse(lat: number, lon: number): Promise<SearchResult | null> {
-    if (!this.GEOCODIO_API_KEY) return null;
-
-    try {
-      const response = await fetch(
-        `https://api.geocod.io/v1.7/reverse?q=${lat},${lon}&api_key=${this.GEOCODIO_API_KEY}`
-      );
-
-      if (!response.ok) return null;
-
-      const data = await response.json();
-      const result = data?.results?.[0];
-      const components = result?.address_components;
-
-      const postcode: string | undefined = components?.zip;
-      if (!postcode) return null;
-      if (components?.country && components.country !== 'US') return null;
-
-      return {
-        lat,
-        lon,
-        display_name: result.formatted_address ?? '',
-        address: {
-          city: components.city,
-          county: components.county,
-          state: components.state,
-          postcode,
-          country: components.country
-        }
-      };
-    } catch (error) {
-      console.error('Geocodio reverse geocoding failed:', error);
       return null;
     }
   }

--- a/src/lib/services/geocoding.ts
+++ b/src/lib/services/geocoding.ts
@@ -5,7 +5,7 @@ export class GeocodingService {
   private static readonly RATE_LIMIT_MS = 1000; // 1 second between requests
   private static readonly USER_AGENT = 'GardenMap/1.0 (https://github.com/tylermachado/gardenmap)';
   private static requestQueue: Promise<void> = Promise.resolve();
-  private static readonly ZIP_API_BASE = 'https://www.mynativeplantlist.com/api/zip';
+  private static readonly ZIP_API_BASE = '/api/zip';
 
   private static hasZipcode(query: string): boolean {
     // Match 5-digit or 5+4 digit ZIP codes
@@ -53,10 +53,13 @@ export class GeocodingService {
 
       const meta = await this.zipMetadata(zipcode);
 
+      const displayName =
+        meta?.city && meta?.state ? `${meta.city}, ${meta.state} ${zipcode}` : zipcode;
+
       return {
         lat,
         lon,
-        display_name: meta ? `${meta.city}, ${meta.state} ${zipcode}` : zipcode,
+        display_name: displayName,
         address: {
           postcode: zipcode,
           city: meta?.city,

--- a/src/lib/types/layer.ts
+++ b/src/lib/types/layer.ts
@@ -46,10 +46,13 @@ export function isLayerSelected(layer: LayerOption, selectedLayers: LayerOption[
 
 export function getCityStateLabel(address: NominatimAddress | null | undefined): string {
   return [
+    address?.neighbourhood,
     address?.suburb,
+    address?.hamlet,
     address?.village,
     address?.town,
     address?.city,
+    address?.municipality,
     address?.state
   ]
     .filter(Boolean)

--- a/src/lib/types/layer.ts
+++ b/src/lib/types/layer.ts
@@ -1,8 +1,11 @@
 export interface NominatimAddress {
+  neighbourhood?: string;
   suburb?: string;
+  hamlet?: string;
   village?: string;
   town?: string;
   city?: string;
+  municipality?: string;
   county?: string;
   state?: string;
   postcode?: string;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -92,30 +92,36 @@
 		Skip to main content
 	</a>
 	<header
-		class="flex flex-col-reverse gap-2 bg-lime-950 p-4 sm:flex-row sm:items-center sm:justify-between sm:gap-0"
+		class="flex flex-col-reverse gap-2 bg-lime-950 p-4 md:relative md:flex-row md:items-center md:justify-end md:gap-0"
 	>
-		<a
-			href="/"
-			class="flex w-full items-center justify-between gap-3 sm:w-auto sm:justify-start"
-		>
-			<h1 class="font-serif text-xl font-bold text-stone-100 sm:text-3xl">My Native Plant List</h1>
-			<div class="flex items-center gap-3">
+		<div class="flex w-full items-center justify-between gap-3 md:w-auto">
+			<a
+				href="/"
+				class="md:absolute md:left-1/2 md:top-1/2 md:-translate-x-1/2 md:-translate-y-1/2"
+			>
+				<h1 class="font-serif text-xl font-bold text-stone-100 md:text-3xl">
+					My Native Plant List
+				</h1>
+			</a>
+			<div
+				class="flex items-center gap-3 md:absolute md:left-0 md:top-1/2 md:-translate-y-1/2"
+			>
 				<span
 					role="img"
 					aria-label="The Sustainable Gardening Institute"
-					class="inline-block h-8 bg-stone-100 sm:h-10"
+					class="inline-block h-[1.8rem] bg-stone-100 md:h-[2.25rem]"
 					style="aspect-ratio: 163.7 / 88; mask: url(/logos/sgi.svg) center / contain no-repeat; -webkit-mask: url(/logos/sgi.svg) center / contain no-repeat;"
 				></span>
 				<span
 					role="img"
 					aria-label="White Flower Farm"
-					class="inline-block h-8 bg-stone-100 sm:h-10"
+					class="inline-block h-[1.8rem] bg-stone-100 md:h-[2.25rem]"
 					style="aspect-ratio: 811.7 / 724.5; mask: url(/logos/wff.svg) center / contain no-repeat; -webkit-mask: url(/logos/wff.svg) center / contain no-repeat;"
 				></span>
 			</div>
-		</a>
+		</div>
 		<nav
-			class="-mx-4 -mt-4 flex w-[calc(100%+2rem)] items-center justify-end gap-4 bg-stone-950 px-4 py-2 sm:m-0 sm:w-auto sm:bg-transparent sm:p-0"
+			class="-mx-4 -mt-4 flex w-[calc(100%+2rem)] items-center justify-end gap-4 bg-stone-950 px-4 py-2 md:m-0 md:w-auto md:bg-transparent md:p-0"
 		>
 			<button
 				onclick={() => (showAbout = true)}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -553,8 +553,8 @@
 				{:else}
 					<CandidatePlants
 						zipcode={searchResultAddress?.postcode}
-						ecoregion={searchResultAddress?.postcode ? undefined : pointLayerData.ecoregions?.NA_L3CODE}
-						phzZone={searchResultAddress?.postcode ? undefined : pointLayerData.phz?.zone}
+						ecoregion={pointLayerData.ecoregions?.NA_L3CODE}
+						phzZone={pointLayerData.phz?.zone}
 						filters={plantFilters}
 					/>
 				{/if}


### PR DESCRIPTION
**Geocoding logic changes:**

* [`src/lib/services/geocoding.ts`](diffhunk://#diff-00a6713026dacb5da1046127a4d89290449467a11e4ede58e1f172ebc228714aL8-R8): Reverse geocoding now uses mynativeplantlist's `/api/zip` endpoint as the primary source for mapping coordinates to ZIP codes and associated metadata. If this lookup fails, it falls back to Nominatim. The Geocodio fallback and its environment variable are removed. [[1]](diffhunk://#diff-00a6713026dacb5da1046127a4d89290449467a11e4ede58e1f172ebc228714aL8-R8) [[2]](diffhunk://#diff-00a6713026dacb5da1046127a4d89290449467a11e4ede58e1f172ebc228714aL32-R108) [[3]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL6-L11)

**Candidate plants fallback improvements:**

* [`src/lib/components/CandidatePlants.svelte`](diffhunk://#diff-43223e8c7243b358857095678b7f430e421c00eb34129553d681090a47281deeR38-R41): When a ZIP-based plant lookup returns no results, the UI now automatically falls back to using ecoregion/hardiness-zone for plant suggestions, ensuring users always see relevant results if possible. The fallback logic is tracked and only triggers once per location. [[1]](diffhunk://#diff-43223e8c7243b358857095678b7f430e421c00eb34129553d681090a47281deeR38-R41) [[2]](diffhunk://#diff-43223e8c7243b358857095678b7f430e421c00eb34129553d681090a47281deeR91-L92) [[3]](diffhunk://#diff-43223e8c7243b358857095678b7f430e421c00eb34129553d681090a47281deeR110-R147) [[4]](diffhunk://#diff-43223e8c7243b358857095678b7f430e421c00eb34129553d681090a47281deeR163) [[5]](diffhunk://#diff-43223e8c7243b358857095678b7f430e421c00eb34129553d681090a47281deeL160-R203)

**Documentation and environment updates:**

* `.env.example`, `README.md`: References to the Geocodio API and its environment variable are removed. Documentation is updated to reflect the new geocoding flow, describing the use of the mynativeplantlist ZIP API and clarifying when Nominatim is used. [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL6-L11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L32-R32) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L68) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L171-R172)

**UI and code consistency fixes:**

* [`src/lib/components/PlantModal.svelte`](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L50-R52): Ensures consistent type comparison when cleaning up the plant modal URL by coercing `plant.id` to a string.
* [`src/routes/+layout.svelte`](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL95-R124): Refactors the header layout for improved responsiveness and alignment, especially on medium-sized screens and above.
* [`src/routes/+page.svelte`](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfL556-R557): Adjusts prop passing to `CandidatePlants` to always provide ecoregion and phzZone, regardless of ZIP presence.