### PR TITLE
Add Share menu and update modal button styles

### DIFF
--- a/src/lib/components/PlantModal.svelte
+++ b/src/lib/components/PlantModal.svelte
@@ -63,8 +63,13 @@
 	let copied = $state(false);
 	let copiedTimeout: ReturnType<typeof setTimeout> | undefined;
 
+	// Built explicitly (not read from $page.url) because the ?plant= param is added via an
+	// async goto() in onMount — $page.url may not have caught up yet if the user shares
+	// immediately after the modal opens.
 	function shareUrl(): string {
-		return $page.url.href;
+		const params = new URLSearchParams($page.url.searchParams);
+		params.set('plant', String(plant.id));
+		return `${$page.url.origin}${$page.url.pathname}?${params.toString()}`;
 	}
 
 	async function copyLink() {

--- a/src/lib/components/PlantModal.svelte
+++ b/src/lib/components/PlantModal.svelte
@@ -78,6 +78,25 @@
 		}
 	}
 
+	// Prefer the native OS share sheet (mobile browsers, Safari) and fall back to
+	// copy-to-clipboard everywhere else.
+	async function share() {
+		if (navigator.share) {
+			try {
+				await navigator.share({
+					title: plant.scientific_name ?? plant.name,
+					text: plant.common_name?.length ? plant.common_name.join(', ') : undefined,
+					url: shareUrl()
+				});
+			} catch (err) {
+				// AbortError just means the user dismissed the share sheet.
+				if ((err as Error)?.name !== 'AbortError') await copyLink();
+			}
+			return;
+		}
+		await copyLink();
+	}
+
 	function trapFocus(e: KeyboardEvent) {
 		if (e.key === 'Escape') {
 			e.preventDefault();
@@ -154,14 +173,14 @@
 {#snippet heartButton()}
 	<button
 		type="button"
-		class="absolute right-20 top-3 flex h-7 w-7 items-center justify-center rounded-full bg-white/90 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 {saved
+		class="absolute right-24 top-3 flex h-9 w-9 items-center justify-center rounded-full bg-white/90 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 {saved
 			? 'text-red-600'
 			: 'text-stone-500 hover:text-stone-800'}"
 		onclick={() => savedPlants.toggle(saveTarget)}
 		aria-pressed={saved}
 		aria-label={saved ? 'Remove from My Saved Plants' : 'Add to My Saved Plants'}
 	>
-		<svg class="h-4 w-4" fill={saved ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+		<svg class="h-5 w-5" fill={saved ? 'currentColor' : 'none'} stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 			<path
 				stroke-linecap="round"
 				stroke-linejoin="round"
@@ -173,31 +192,31 @@
 {/snippet}
 
 {#snippet shareButton()}
-	<div class="absolute right-12 top-3">
+	<div class="absolute right-14 top-3">
 		<button
 			type="button"
-			class="flex h-7 w-7 items-center justify-center rounded-full bg-white/90 text-stone-500 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 hover:text-stone-800"
-			onclick={copyLink}
-			aria-label="Copy link to this plant"
+			class="flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-stone-500 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 hover:text-stone-800"
+			onclick={share}
+			aria-label="Share this plant"
 		>
 			{#if copied}
-				<svg class="h-4 w-4 text-lime-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+				<svg class="h-5 w-5 text-lime-700" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 				</svg>
 			{:else}
-				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+				<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
 					<path
 						stroke-linecap="round"
 						stroke-linejoin="round"
 						stroke-width="2"
-						d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+						d="M7.5 7.5h-.75A2.25 2.25 0 0 0 4.5 9.75v7.5a2.25 2.25 0 0 0 2.25 2.25h7.5a2.25 2.25 0 0 0 2.25-2.25v-7.5a2.25 2.25 0 0 0-2.25-2.25h-.75m0-3-3-3m0 0-3 3m3-3v11.25"
 					/>
 				</svg>
 			{/if}
 		</button>
 		<span
 			aria-live="polite"
-			class="pointer-events-none absolute right-0 top-9 whitespace-nowrap rounded bg-stone-800 px-2 py-1 text-[11px] text-white shadow transition-opacity duration-200 {copied ? 'opacity-100' : 'opacity-0'}"
+			class="pointer-events-none absolute right-0 top-11 whitespace-nowrap rounded bg-stone-800 px-2 py-1 text-[11px] text-white shadow transition-opacity duration-200 {copied ? 'opacity-100' : 'opacity-0'}"
 		>
 			{copied ? 'Link copied!' : ''}
 		</span>
@@ -266,7 +285,7 @@
 				{@render shareButton()}
 				<button
 					type="button"
-					class="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full bg-white/90 text-stone-500 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 hover:text-stone-800"
+					class="absolute right-3 top-3 flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-lg text-stone-500 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 hover:text-stone-800"
 					onclick={onclose}
 					aria-label="Close"
 					bind:this={closeBtn}
@@ -360,7 +379,7 @@
 			{@render shareButton()}
 			<button
 				type="button"
-				class="absolute right-3 top-3 flex h-7 w-7 items-center justify-center rounded-full bg-white/90 text-stone-500 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 hover:text-stone-800"
+				class="absolute right-3 top-3 flex h-9 w-9 items-center justify-center rounded-full bg-white/90 text-lg text-stone-500 shadow ring-1 ring-black/5 backdrop-blur-sm hover:bg-stone-100 hover:text-stone-800"
 				onclick={onclose}
 				aria-label="Close"
 				bind:this={closeBtn}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../app.css';
-	import { onMount } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
+	import { page } from '$app/stores';
 	import InfoModal from '$lib/components/InfoModal.svelte';
 	import SavedPlantsTab from '$lib/components/SavedPlantsTab.svelte';
 
@@ -11,6 +12,42 @@
 	onMount(() => {
 		mounted = true;
 	});
+
+	let copied = $state(false);
+	let copiedTimeout: ReturnType<typeof setTimeout> | undefined;
+
+	onDestroy(() => {
+		clearTimeout(copiedTimeout);
+	});
+
+	async function copyLink() {
+		try {
+			await navigator.clipboard.writeText($page.url.href);
+			copied = true;
+			clearTimeout(copiedTimeout);
+			copiedTimeout = setTimeout(() => (copied = false), 1500);
+		} catch {
+			// Clipboard API unavailable (e.g. insecure context); nothing more we can do here.
+		}
+	}
+
+	// Prefer the native OS share sheet (mobile browsers, Safari) and fall back to
+	// copy-to-clipboard everywhere else.
+	async function share() {
+		if (navigator.share) {
+			try {
+				await navigator.share({
+					title: document.title,
+					url: $page.url.href
+				});
+			} catch (err) {
+				// AbortError just means the user dismissed the share sheet.
+				if ((err as Error)?.name !== 'AbortError') await copyLink();
+			}
+			return;
+		}
+		await copyLink();
+	}
 </script>
 
 <svelte:head>
@@ -132,6 +169,31 @@
 				class="text-sm font-normal text-stone-300 no-underline transition-colors hover:text-stone-100"
 				>Terms of Use</a
 			>
+			<div class="relative hidden md:block">
+				<button
+					type="button"
+					onclick={share}
+					class="flex items-center text-stone-300 transition-colors hover:text-stone-100"
+					aria-label="Share this page"
+				>
+					<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M7.5 7.5h-.75A2.25 2.25 0 0 0 4.5 9.75v7.5a2.25 2.25 0 0 0 2.25 2.25h7.5a2.25 2.25 0 0 0 2.25-2.25v-7.5a2.25 2.25 0 0 0-2.25-2.25h-.75m0-3-3-3m0 0-3 3m3-3v11.25"
+						/>
+					</svg>
+				</button>
+				<span
+					aria-live="polite"
+					class="pointer-events-none absolute right-0 top-full mt-1 whitespace-nowrap rounded bg-stone-800 px-2 py-1 text-[11px] text-white shadow transition-opacity duration-200 {copied
+						? 'opacity-100'
+						: 'opacity-0'}"
+				>
+					{copied ? 'Link copied!' : ''}
+				</span>
+			</div>
 		</nav>
 	</header>
 


### PR DESCRIPTION
**Sharing functionality improvements:**

* Added a `share()` function to both `PlantModal.svelte` and `+layout.svelte` components, which uses the native OS share sheet when available and falls back to copying the page URL to the clipboard; also improved error handling for user cancellation and clipboard failures. [[1]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2R81-R99) [[2]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR15-R50)
* Introduced a share button in the site footer (`+layout.svelte`) for desktop users, with visual feedback when the link is copied.

**Modal UI and accessibility updates:**

* Increased the size of modal action buttons (heart, share, close) and their SVG icons for better accessibility and touch targets in `PlantModal.svelte`. [[1]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L157-R183) [[2]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L176-R219) [[3]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L269-R288) [[4]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L363-R382)
* Adjusted the positioning of modal action buttons to accommodate the new sizes and maintain visual balance. [[1]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L157-R183) [[2]](diffhunk://#diff-a451902c2baff8aecfee8a145d2424a51e060ff19d61af9b8550cc6a1ce3e7a2L176-R219)

**Code organization:**

* Updated imports in `+layout.svelte` to include `onDestroy` for proper cleanup of timeouts related to the share/copy feedback.