### PR TITLE
fix inconsistent geocoding

### DIFF
--- a/src/lib/services/geocoding.ts
+++ b/src/lib/services/geocoding.ts
@@ -1,4 +1,5 @@
 import type { SearchResult, NominatimAddress } from '../types/layer.js';
+import { toFullStateName } from '../utils/usStates.js';
 
 export class GeocodingService {
   private static lastRequestTime = 0;
@@ -11,6 +12,23 @@ export class GeocodingService {
     // Match 5-digit or 5+4 digit ZIP codes
     const zipRegex = /\b\d{5}(?:-\d{4})?\b/;
     return zipRegex.test(query);
+  }
+
+  private static extractZipcode(query: string): string | null {
+    const match = query.match(/\b\d{5}(?:-\d{4})?\b/);
+    return match ? match[0].slice(0, 5) : null;
+  }
+
+  private static hasPlaceName(address: NominatimAddress | undefined): boolean {
+    return Boolean(
+      address?.neighbourhood ||
+        address?.suburb ||
+        address?.hamlet ||
+        address?.village ||
+        address?.town ||
+        address?.city ||
+        address?.municipality
+    );
   }
 
   private static rateLimitedFetch(url: string): Promise<Response> {
@@ -85,7 +103,7 @@ export class GeocodingService {
       if (!response.ok) return null;
 
       const data = await response.json();
-      return { city: data?.city, state: data?.state };
+      return { city: data?.city, state: toFullStateName(data?.state) };
     } catch (error) {
       console.error('ZIP metadata lookup failed:', error);
       return null;
@@ -130,13 +148,27 @@ export class GeocodingService {
       
       const results = await response.json();
       const result = results?.[0];
-      
+
       if (!result) return null;
-      
+
+      const address: NominatimAddress = result.address ?? {};
+
+      // Nominatim's postcode boundaries sometimes lack a city/town/village tag
+      // (e.g. unincorporated ZCTAs like 99154/Mohler, WA). Fill in from the
+      // Census-backed ZIP metadata used for map-click reverse geocoding, so
+      // both paths resolve to the same place name.
+      if (!this.hasPlaceName(address)) {
+        const zipcode = this.extractZipcode(query);
+        const meta = zipcode ? await this.zipMetadata(zipcode) : null;
+        if (meta?.city) {
+          address.city = meta.city;
+        }
+      }
+
       return {
         lat: parseFloat(result.lat),
         lon: parseFloat(result.lon),
-        address: result.address,
+        address,
         display_name: result.display_name
       };
     } catch (error) {

--- a/src/lib/services/geocoding.ts
+++ b/src/lib/services/geocoding.ts
@@ -122,9 +122,10 @@ export class GeocodingService {
       const result = response.ok ? await response.json() : null;
 
       const hasUsAddress = result?.address && result.address.country_code === 'us';
-      return hasUsAddress
-        ? { lat, lon, address: result.address, display_name: result.display_name }
-        : null;
+      if (!hasUsAddress) return null;
+
+      const address: NominatimAddress = { ...result.address, state: toFullStateName(result.address.state) };
+      return { lat, lon, address, display_name: result.display_name };
     } catch (error) {
       console.error('Reverse geocoding failed:', error);
       return null;
@@ -164,6 +165,8 @@ export class GeocodingService {
           address.city = meta.city;
         }
       }
+
+      address.state = toFullStateName(address.state);
 
       return {
         lat: parseFloat(result.lat),

--- a/src/lib/types/layer.ts
+++ b/src/lib/types/layer.ts
@@ -1,3 +1,5 @@
+import { toFullStateName } from '../utils/usStates.js';
+
 export interface NominatimAddress {
   neighbourhood?: string;
   suburb?: string;
@@ -55,5 +57,5 @@ export function getCityStateLabel(address: NominatimAddress | null | undefined):
     address?.municipality ??
     address?.county;
 
-  return [place, address?.state].filter(Boolean).join(', ');
+  return [place, toFullStateName(address?.state)].filter(Boolean).join(', ');
 }

--- a/src/lib/types/layer.ts
+++ b/src/lib/types/layer.ts
@@ -45,16 +45,15 @@ export function isLayerSelected(layer: LayerOption, selectedLayers: LayerOption[
 }
 
 export function getCityStateLabel(address: NominatimAddress | null | undefined): string {
-  return [
-    address?.neighbourhood,
-    address?.suburb,
-    address?.hamlet,
-    address?.village,
-    address?.town,
-    address?.city,
-    address?.municipality,
-    address?.state
-  ]
-    .filter(Boolean)
-    .join(', ');
+  const place =
+    address?.neighbourhood ??
+    address?.suburb ??
+    address?.hamlet ??
+    address?.village ??
+    address?.town ??
+    address?.city ??
+    address?.municipality ??
+    address?.county;
+
+  return [place, address?.state].filter(Boolean).join(', ');
 }

--- a/src/lib/utils/usStates.ts
+++ b/src/lib/utils/usStates.ts
@@ -1,0 +1,69 @@
+const STATE_NAMES_BY_ABBREVIATION: Record<string, string> = {
+  AL: 'Alabama',
+  AK: 'Alaska',
+  AZ: 'Arizona',
+  AR: 'Arkansas',
+  CA: 'California',
+  CO: 'Colorado',
+  CT: 'Connecticut',
+  DE: 'Delaware',
+  DC: 'District of Columbia',
+  FL: 'Florida',
+  GA: 'Georgia',
+  HI: 'Hawaii',
+  ID: 'Idaho',
+  IL: 'Illinois',
+  IN: 'Indiana',
+  IA: 'Iowa',
+  KS: 'Kansas',
+  KY: 'Kentucky',
+  LA: 'Louisiana',
+  ME: 'Maine',
+  MD: 'Maryland',
+  MA: 'Massachusetts',
+  MI: 'Michigan',
+  MN: 'Minnesota',
+  MS: 'Mississippi',
+  MO: 'Missouri',
+  MT: 'Montana',
+  NE: 'Nebraska',
+  NV: 'Nevada',
+  NH: 'New Hampshire',
+  NJ: 'New Jersey',
+  NM: 'New Mexico',
+  NY: 'New York',
+  NC: 'North Carolina',
+  ND: 'North Dakota',
+  OH: 'Ohio',
+  OK: 'Oklahoma',
+  OR: 'Oregon',
+  PA: 'Pennsylvania',
+  RI: 'Rhode Island',
+  SC: 'South Carolina',
+  SD: 'South Dakota',
+  TN: 'Tennessee',
+  TX: 'Texas',
+  UT: 'Utah',
+  VT: 'Vermont',
+  VA: 'Virginia',
+  WA: 'Washington',
+  WV: 'West Virginia',
+  WI: 'Wisconsin',
+  WY: 'Wyoming',
+  AS: 'American Samoa',
+  GU: 'Guam',
+  MP: 'Northern Mariana Islands',
+  PR: 'Puerto Rico',
+  VI: 'U.S. Virgin Islands'
+};
+
+/**
+ * Expands a US state postal abbreviation (e.g. "WA") to its full name
+ * (e.g. "Washington"). Returns the input unchanged if it isn't a recognized
+ * 2-letter abbreviation, so already-full names pass through untouched.
+ */
+export function toFullStateName(state: string | undefined | null): string | undefined {
+  if (!state) return undefined;
+  const abbreviation = state.trim().toUpperCase();
+  return STATE_NAMES_BY_ABBREVIATION[abbreviation] ?? state;
+}


### PR DESCRIPTION
**US State Name Handling:**

* Added a utility function `toFullStateName` in `src/lib/utils/usStates.ts` to expand US state postal abbreviations to their full state names. This helps ensure that state names are consistently displayed in their full form across the application.
* Updated the geocoding ZIP metadata lookup in `GeocodingService` to use the new `toFullStateName` function, so state values returned are always the full state name.

**Geocoding Improvements:**

* Improved geocoding result handling in `GeocodingService` so that if a place name (city/town/village, etc.) is missing from the geocoder (common with some ZIP code boundaries), it falls back to using city data from the ZIP code metadata, ensuring consistent place naming.
* Added helper methods `extractZipcode` and `hasPlaceName` to support the above logic for ZIP extraction and place name detection.

**Display Label Refinement:**

* Updated `getCityStateLabel` in `src/lib/types/layer.ts` to prioritize the most specific available place name, now including `county` as a fallback, and to use the new state name handling for improved display consistency.